### PR TITLE
Initialize workspace skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install LLVM and Z3 (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install llvm -y
+          choco install z3 -y
+      - name: Install LLVM and Z3 (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-dev clang z3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: clippy,rustfmt
+      - name: Build
+        run: cargo build --all --verbose
+      - name: Run Tests
+        run: cargo test --all --verbose
+      - name: Clippy Check
+        run: cargo clippy --all -- -D warnings
+      - name: Rustfmt Check
+        run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = ["flux_lang", "fluxc", "fluxd"]
+resolver = "2"
+
+[workspace.dev-dependencies]
+assert_cmd = "2.0"

--- a/benches/compile_bench.rs
+++ b/benches/compile_bench.rs
@@ -1,0 +1,3 @@
+fn main() {
+    // Placeholder benchmark
+}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to FluxLang
+
+Thank you for considering contributing!

--- a/docs/language_spec.md
+++ b/docs/language_spec.md
@@ -1,0 +1,3 @@
+# FluxLang Language Specification (Draft)
+
+This document will describe the syntax and semantics of FluxLang.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,3 @@
+# FluxLang Tutorial
+
+Work in progress.

--- a/examples/hello.flux
+++ b/examples/hello.flux
@@ -1,0 +1,1 @@
+print("Hello, world!")

--- a/examples/refinement.flux
+++ b/examples/refinement.flux
@@ -1,0 +1,1 @@
+let x: Int where x > 0 = 1

--- a/examples/streams.flux
+++ b/examples/streams.flux
@@ -1,0 +1,1 @@
+stream numbers = [1,2,3]

--- a/flux_lang/Cargo.toml
+++ b/flux_lang/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "flux_lang"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+[dependencies]
+lalrpop-util = "0.19"
+
+[build-dependencies]
+lalrpop = "0.19"

--- a/flux_lang/build.rs
+++ b/flux_lang/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    // Generate parser from grammar.lalrpop
+    println!("cargo:rerun-if-changed=src/syntax/grammar.lalrpop");
+    lalrpop::process_root().unwrap();
+}

--- a/flux_lang/src/lib.rs
+++ b/flux_lang/src/lib.rs
@@ -1,0 +1,9 @@
+//! Core compiler library for FluxLang.
+
+pub mod syntax;
+
+/// Stub compile entry point.
+pub fn compile(_source: &str) -> Result<(), String> {
+    // TODO: implement compilation pipeline
+    Ok(())
+}

--- a/flux_lang/src/syntax/ast.rs
+++ b/flux_lang/src/syntax/ast.rs
@@ -1,0 +1,4 @@
+//! Abstract syntax tree definitions for FluxLang.
+
+#[derive(Debug, PartialEq)]
+pub struct Program;

--- a/flux_lang/src/syntax/grammar.lalrpop
+++ b/flux_lang/src/syntax/grammar.lalrpop
@@ -1,0 +1,9 @@
+// Minimal grammar for FluxLang
+
+extern crate lalrpop_util;
+
+use crate::syntax::ast::Program;
+
+pub Program: Program = {
+    <_:#"[a-zA-Z]*"> => Program,
+};

--- a/flux_lang/src/syntax/lexer.rs
+++ b/flux_lang/src/syntax/lexer.rs
@@ -1,0 +1,4 @@
+//! Placeholder lexer.
+
+#[derive(Debug, PartialEq)]
+pub struct Token;

--- a/flux_lang/src/syntax/mod.rs
+++ b/flux_lang/src/syntax/mod.rs
@@ -1,0 +1,8 @@
+//! Syntax definitions and parser.
+
+use lalrpop_util::lalrpop_mod;
+
+lalrpop_mod!(pub grammar); // Generated parser
+
+pub mod ast;
+pub mod lexer;

--- a/fluxc/Cargo.toml
+++ b/fluxc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fluxc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.0", features = ["derive"] }
+flux_lang = { path = "../flux_lang" }

--- a/fluxc/src/main.rs
+++ b/fluxc/src/main.rs
@@ -1,0 +1,14 @@
+use clap::Parser;
+
+/// FluxLang compiler CLI
+#[derive(Parser)]
+struct Cli {
+    /// Input file
+    #[arg(value_name = "FILE")]
+    input: String,
+}
+
+fn main() {
+    let _args = Cli::parse();
+    println!("fluxc stub");
+}

--- a/fluxd/Cargo.toml
+++ b/fluxd/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "fluxd"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+flux_lang = { path = "../flux_lang" }
+tower-lsp = "0.20"
+tokio = { version = "1", features = ["full"] }

--- a/fluxd/src/main.rs
+++ b/fluxd/src/main.rs
@@ -1,0 +1,11 @@
+use tower_lsp::LspService;
+use tower_lsp::Server;
+
+#[tokio::main]
+async fn main() {
+    println!("fluxd stub");
+    let (service, socket) = LspService::new(|_client| async move { () });
+    Server::new(tokio::io::stdin(), tokio::io::stdout(), socket)
+        .serve(service)
+        .await;
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,7 @@
+use assert_cmd::Command;
+
+#[test]
+fn runs_fluxc() {
+    let mut cmd = Command::cargo_bin("fluxc").unwrap();
+    cmd.arg("input.flux").assert().success();
+}

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1,0 +1,6 @@
+use flux_lang::compile;
+
+#[test]
+fn compile_empty_source() {
+    assert!(compile("").is_ok());
+}


### PR DESCRIPTION
## Summary
- scaffold Cargo workspace for flux-lang compiler
- stub library crate with minimal parser
- add CLI and LSP binary crates
- include examples, docs and tests
- set up CI workflow targeting master branch

## Testing
- `cargo clippy --all -- -D warnings` *(fails: failed to fetch crates)*
- `cargo build --all --verbose` *(fails: could not download dependencies)*
