### PR TITLE
Fix lalrpop grammar build

### DIFF
--- a/flux_lang/Cargo.toml
+++ b/flux_lang/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-lalrpop-util = "0.19"
+lalrpop-util = { version = "0.19", features = ["lexer"] }
 
 [build-dependencies]
 lalrpop = "0.19"

--- a/flux_lang/src/syntax/grammar.lalrpop
+++ b/flux_lang/src/syntax/grammar.lalrpop
@@ -1,9 +1,9 @@
 // Minimal grammar for FluxLang
 
-extern crate lalrpop_util;
-
 use crate::syntax::ast::Program;
 
+grammar;
+
 pub Program: Program = {
-    <_:#"[a-zA-Z]*"> => Program,
+    <r"[a-zA-Z]*"> => Program,
 };

--- a/flux_lang/src/syntax/mod.rs
+++ b/flux_lang/src/syntax/mod.rs
@@ -2,7 +2,8 @@
 
 use lalrpop_util::lalrpop_mod;
 
-lalrpop_mod!(pub grammar); // Generated parser
+// Generated parser from grammar.lalrpop
+lalrpop_mod!(pub grammar, "/syntax/grammar.rs");
 
 pub mod ast;
 pub mod lexer;

--- a/fluxd/src/main.rs
+++ b/fluxd/src/main.rs
@@ -1,10 +1,25 @@
-use tower_lsp::LspService;
-use tower_lsp::Server;
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::{InitializeParams, InitializeResult};
+use tower_lsp::{Client, LanguageServer, LspService, Server};
+
+#[derive(Debug)]
+struct Backend;
+
+#[tower_lsp::async_trait]
+impl LanguageServer for Backend {
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult::default())
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+}
 
 #[tokio::main]
 async fn main() {
     println!("fluxd stub");
-    let (service, socket) = LspService::new(|_client| async move { () });
+    let (service, socket) = LspService::new(|_client: Client| Backend);
     Server::new(tokio::io::stdin(), tokio::io::stdout(), socket)
         .serve(service)
         .await;


### PR DESCRIPTION
## Summary
- fix lalrpop grammar path
- enable lalrpop lexer feature
- add minimal LanguageServer stub for fluxd
- update grammar syntax

## Testing
- `cargo test --offline`