### PR TITLE
Add compiler module stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/flux_lang/src/codegen/cranelift.rs
+++ b/flux_lang/src/codegen/cranelift.rs
@@ -1,0 +1,6 @@
+use crate::ir::IrModule;
+
+pub fn emit_cranelift(_ir: &IrModule) -> Result<(), String> {
+    // TODO: implement Cranelift JIT backend
+    Ok(())
+}

--- a/flux_lang/src/codegen/llvm.rs
+++ b/flux_lang/src/codegen/llvm.rs
@@ -1,0 +1,6 @@
+use crate::ir::IrModule;
+
+pub fn emit_llvm(_ir: &IrModule) -> Result<(), String> {
+    // TODO: implement LLVM backend
+    Ok(())
+}

--- a/flux_lang/src/codegen/mod.rs
+++ b/flux_lang/src/codegen/mod.rs
@@ -2,7 +2,11 @@
 
 use crate::ir::IrModule;
 
-pub fn emit(_ir: &IrModule) -> Result<(), String> {
-    // TODO: implement code generation
-    Ok(())
+pub mod cranelift;
+pub mod llvm;
+pub mod wasm;
+
+pub fn emit(ir: &IrModule) -> Result<(), String> {
+    // TODO: choose backend via options
+    llvm::emit_llvm(ir)
 }

--- a/flux_lang/src/codegen/wasm.rs
+++ b/flux_lang/src/codegen/wasm.rs
@@ -1,0 +1,6 @@
+use crate::ir::IrModule;
+
+pub fn emit_wasm(_ir: &IrModule) -> Result<(), String> {
+    // TODO: implement WASM backend
+    Ok(())
+}

--- a/flux_lang/src/ir/ir.rs
+++ b/flux_lang/src/ir/ir.rs
@@ -1,0 +1,13 @@
+use crate::syntax::ast::Program;
+use petgraph::graph::Graph;
+
+pub struct IrModule {
+    pub graph: Graph<(), ()>,
+}
+
+pub fn lower(_program: &Program) -> IrModule {
+    // TODO: implement lowering from AST to IR
+    IrModule {
+        graph: Graph::new(),
+    }
+}

--- a/flux_lang/src/ir/mod.rs
+++ b/flux_lang/src/ir/mod.rs
@@ -1,23 +1,9 @@
 //! Intermediate representation definitions
 
-use crate::syntax::ast::Program;
-use petgraph::graph::Graph;
+#![allow(clippy::module_inception)]
 
-pub struct IrModule {
-    pub graph: Graph<(), ()>,
-}
+pub mod ir;
+pub mod optimize;
 
-pub fn lower(_program: &Program) -> IrModule {
-    // TODO: implement lowering from AST to IR
-    IrModule {
-        graph: Graph::new(),
-    }
-}
-
-pub mod opt {
-    use super::IrModule;
-
-    pub fn run_passes(_ir: &mut IrModule) {
-        // TODO: implement optimization passes
-    }
-}
+pub use ir::{lower, IrModule};
+pub use optimize::run_passes;

--- a/flux_lang/src/ir/optimize.rs
+++ b/flux_lang/src/ir/optimize.rs
@@ -1,0 +1,5 @@
+use super::IrModule;
+
+pub fn run_passes(_ir: &mut IrModule) {
+    // TODO: implement optimization passes
+}

--- a/flux_lang/src/lib.rs
+++ b/flux_lang/src/lib.rs
@@ -2,8 +2,8 @@
 
 pub mod codegen;
 pub mod ir;
+pub mod semantic;
 pub mod syntax;
-pub mod typeck;
 
 /// Stub compile entry point.
 pub fn compile(source: &str) -> Result<(), String> {
@@ -13,11 +13,11 @@ pub fn compile(source: &str) -> Result<(), String> {
         .map_err(|e| format!("parse error: {e}"))?;
 
     // Type check
-    typeck::check(&ast)?;
+    semantic::check(&ast)?;
 
     // Lower to IR and optimize
     let mut ir = ir::lower(&ast);
-    ir::opt::run_passes(&mut ir);
+    ir::run_passes(&mut ir);
 
     // Emit code (placeholder)
     codegen::emit(&ir)?;

--- a/flux_lang/src/semantic/env.rs
+++ b/flux_lang/src/semantic/env.rs
@@ -1,0 +1,10 @@
+//! Symbol table and type environments (placeholder)
+
+pub struct Env;
+
+#[allow(clippy::new_without_default)]
+impl Env {
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/flux_lang/src/semantic/mod.rs
+++ b/flux_lang/src/semantic/mod.rs
@@ -1,0 +1,6 @@
+//! Semantic analysis and type checking stubs
+
+pub mod env;
+pub mod typecheck;
+
+pub use typecheck::check;

--- a/flux_lang/src/semantic/typecheck.rs
+++ b/flux_lang/src/semantic/typecheck.rs
@@ -1,8 +1,8 @@
-//! Stub type checker
-
+use super::env::Env;
 use crate::syntax::ast::Program;
 
 pub fn check(_program: &Program) -> Result<(), String> {
+    let _env = Env::new();
     // TODO: implement type checking
     Ok(())
 }

--- a/flux_lang/src/syntax/mod.rs
+++ b/flux_lang/src/syntax/mod.rs
@@ -1,9 +1,10 @@
 //! Syntax definitions and parser.
 
-use lalrpop_util::lalrpop_mod;
-
 // Include generated parser from build script
-lalrpop_mod!(pub grammar, "/syntax/grammar.rs");
+#[allow(clippy::all)]
+pub mod grammar {
+    include!(concat!(env!("OUT_DIR"), "/syntax/grammar.rs"));
+}
 
 pub mod ast;
 pub mod lexer;

--- a/flux_lang/tests/typechecker_tests.rs
+++ b/flux_lang/tests/typechecker_tests.rs
@@ -1,0 +1,6 @@
+use flux_lang::compile;
+
+#[test]
+fn typechecker_stub() {
+    assert!(compile("dummy").is_ok());
+}


### PR DESCRIPTION
## Summary
- stub out semantic analysis module with env and typecheck
- split IR implementation into separate modules
- scaffold code generation backends (LLVM, Cranelift, WASM)
- add a placeholder typechecker integration test
- ignore build artifacts

## Testing
- `cargo clippy --all -- -D warnings`
- `cargo test --all --quiet`
