### PR TITLE
Add rustfmt step to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           toolchain: stable
           override: true
-          components: clippy
+          components: clippy,rustfmt
       - name: Clippy Check
         run: cargo clippy --all -- -D warnings
+      - name: Rustfmt Check
+        run: cargo fmt -- --check


### PR DESCRIPTION
## Summary
- ensure lint workflow runs `cargo fmt -- --check`

## Testing
- `cargo fmt --all`
- `cargo test`