### PR TITLE
Stub macro and plugin frameworks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ resolver = "2"
 
 [workspace.dev-dependencies]
 assert_cmd = "2.0"
+quickcheck = "1.0"

--- a/flux_lang/Cargo.toml
+++ b/flux_lang/Cargo.toml
@@ -7,8 +7,10 @@ build = "build.rs"
 [dependencies]
 lalrpop-util = { version = "0.19", features = ["lexer"] }
 petgraph = "0.6"
+once_cell = "1.19"
 
 [build-dependencies]
 lalrpop = "0.19"
 
 [dev-dependencies]
+quickcheck = "1.0"

--- a/flux_lang/src/lib.rs
+++ b/flux_lang/src/lib.rs
@@ -2,15 +2,23 @@
 
 pub mod codegen;
 pub mod ir;
+pub mod macros;
+pub mod plugins;
 pub mod semantic;
 pub mod syntax;
 
 /// Stub compile entry point.
 pub fn compile(source: &str) -> Result<(), String> {
     // Parse source into AST
-    let ast = syntax::grammar::ProgramParser::new()
+    let mut ast = syntax::grammar::ProgramParser::new()
         .parse(source)
         .map_err(|e| format!("parse error: {e}"))?;
+
+    // Expand macros
+    macros::expand(&mut ast);
+
+    // Run registered plugins
+    plugins::run_all(&mut ast);
 
     // Type check
     semantic::check(&ast)?;

--- a/flux_lang/src/macros.rs
+++ b/flux_lang/src/macros.rs
@@ -1,0 +1,7 @@
+use crate::syntax::ast::Program;
+
+/// Expand macros in the given program.
+pub fn expand(program: &mut Program) {
+    let _ = program; // suppress unused variable warning
+                     // TODO: implement hygienic macro expansion
+}

--- a/flux_lang/src/plugins/mod.rs
+++ b/flux_lang/src/plugins/mod.rs
@@ -1,0 +1,19 @@
+use crate::syntax::ast::Program;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+pub trait Plugin: Send + Sync {
+    fn run(&self, program: &mut Program);
+}
+
+static PLUGINS: Lazy<Mutex<Vec<Box<dyn Plugin>>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+pub fn register(plugin: Box<dyn Plugin>) {
+    PLUGINS.lock().unwrap().push(plugin);
+}
+
+pub fn run_all(program: &mut Program) {
+    for plugin in PLUGINS.lock().unwrap().iter() {
+        plugin.run(program);
+    }
+}

--- a/flux_lang/tests/property_tests.rs
+++ b/flux_lang/tests/property_tests.rs
@@ -1,0 +1,7 @@
+use quickcheck::quickcheck;
+
+quickcheck! {
+    fn addition_commutes(x: i32, y: i32) -> bool {
+        x + y == y + x
+    }
+}


### PR DESCRIPTION
## Summary
- stub macro expansion module
- add plugin registration API
- integrate macros and plugins into compile() flow
- add property-based test using `quickcheck`
- include `quickcheck` and `once_cell` dependencies

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings` *(failed: failed to get `lalrpop-util` due to network)*
- `cargo test --all --verbose` *(failed: failed to get `lalrpop-util` due to network)*