### PR TITLE
Continue project scaffolding

### DIFF
--- a/flux_lang/src/lib.rs
+++ b/flux_lang/src/lib.rs
@@ -17,7 +17,8 @@ pub fn compile(source: &str) -> Result<(), String> {
     // Expand macros
     macros::expand(&mut ast);
 
-    // Run registered plugins
+    // Register and run development plugins
+    plugins::register_default_plugins();
     plugins::run_all(&mut ast);
 
     // Type check

--- a/flux_lang/src/plugins/example.rs
+++ b/flux_lang/src/plugins/example.rs
@@ -1,0 +1,11 @@
+use super::Plugin;
+use crate::syntax::ast::Program;
+
+/// Simple plugin that dumps the AST for debugging.
+pub struct DumpAstPlugin;
+
+impl Plugin for DumpAstPlugin {
+    fn run(&self, program: &mut Program) {
+        println!("[plugin] AST: {:?}", program);
+    }
+}

--- a/flux_lang/src/plugins/mod.rs
+++ b/flux_lang/src/plugins/mod.rs
@@ -6,6 +6,8 @@ pub trait Plugin: Send + Sync {
     fn run(&self, program: &mut Program);
 }
 
+pub mod example;
+
 static PLUGINS: Lazy<Mutex<Vec<Box<dyn Plugin>>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
 pub fn register(plugin: Box<dyn Plugin>) {
@@ -16,4 +18,9 @@ pub fn run_all(program: &mut Program) {
     for plugin in PLUGINS.lock().unwrap().iter() {
         plugin.run(program);
     }
+}
+
+/// Register built-in plugins used during development.
+pub fn register_default_plugins() {
+    register(Box::new(example::DumpAstPlugin));
 }

--- a/flux_lang/tests/cli_tests.rs
+++ b/flux_lang/tests/cli_tests.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 fn runs_fluxc() {
     if let Ok(exe) = std::env::var("CARGO_BIN_EXE_fluxc") {
         let status = Command::new(exe)
-            .arg("input.flux")
+            .args(["compile", "examples/hello.flux"])
             .status()
             .expect("failed to run fluxc");
         assert!(status.success());

--- a/flux_lang/tests/property_tests.rs
+++ b/flux_lang/tests/property_tests.rs
@@ -2,6 +2,6 @@ use quickcheck::quickcheck;
 
 quickcheck! {
     fn addition_commutes(x: i32, y: i32) -> bool {
-        x + y == y + x
+        x.wrapping_add(y) == y.wrapping_add(x)
     }
 }

--- a/fluxc/src/main.rs
+++ b/fluxc/src/main.rs
@@ -1,14 +1,37 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use std::fs;
 
 /// FluxLang compiler CLI
 #[derive(Parser)]
+#[command(author, version, about)]
 struct Cli {
-    /// Input file
-    #[arg(value_name = "FILE")]
-    input: String,
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Compile a FluxLang source file
+    Compile {
+        #[arg(value_name = "FILE")]
+        input: String,
+    },
+    /// Interactive REPL (not yet implemented)
+    Repl,
 }
 
 fn main() {
-    let _args = Cli::parse();
-    println!("fluxc stub");
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Compile { input } => {
+            let source = fs::read_to_string(&input).expect("failed to read input");
+            if let Err(e) = flux_lang::compile(&source) {
+                eprintln!("compile error: {e}");
+            }
+        }
+        Commands::Repl => {
+            println!("REPL stub");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- register a simple example plugin
- expose plugin registration in compiler entrypoint
- expand `fluxc` CLI with subcommands
- fix property-based test to avoid overflow
- adjust CLI test for new compile command

## Testing
- `cargo test --workspace --quiet`
- `cargo clippy --all -- -D warnings`
- `cargo fmt -- --check`
