### PR TITLE
Remove redundant lint steps from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-          components: clippy,rustfmt
       - name: Build
         run: cargo build --all --verbose
       - name: Run Tests
         run: cargo test --all --verbose
-      - name: Clippy Check
-        run: cargo clippy --all -- -D warnings
-      - name: Rustfmt Check
-        run: cargo fmt --all -- --check


### PR DESCRIPTION
## Summary
- streamline CI workflow
- rely on lint.yml for clippy and fmt checks

## Testing
- `cargo fmt --all -- --check`
