### PR TITLE
Implement backend selection

### DIFF
--- a/flux_lang/src/codegen/mod.rs
+++ b/flux_lang/src/codegen/mod.rs
@@ -2,11 +2,27 @@
 
 use crate::ir::IrModule;
 
+/// Available code generation backends.
+#[derive(Clone, Copy, Debug)]
+pub enum Backend {
+    Llvm,
+    Cranelift,
+    Wasm,
+}
+
 pub mod cranelift;
 pub mod llvm;
 pub mod wasm;
 
 pub fn emit(ir: &IrModule) -> Result<(), String> {
-    // TODO: choose backend via options
-    llvm::emit_llvm(ir)
+    emit_with_backend(ir, Backend::Llvm)
+}
+
+/// Emit code for the given IR using the selected backend.
+pub fn emit_with_backend(ir: &IrModule, backend: Backend) -> Result<(), String> {
+    match backend {
+        Backend::Llvm => llvm::emit_llvm(ir),
+        Backend::Cranelift => cranelift::emit_cranelift(ir),
+        Backend::Wasm => wasm::emit_wasm(ir),
+    }
 }

--- a/flux_lang/src/lib.rs
+++ b/flux_lang/src/lib.rs
@@ -9,6 +9,11 @@ pub mod syntax;
 
 /// Stub compile entry point.
 pub fn compile(source: &str) -> Result<(), String> {
+    compile_with_backend(source, codegen::Backend::Llvm)
+}
+
+/// Compile FluxLang source using the specified backend.
+pub fn compile_with_backend(source: &str, backend: codegen::Backend) -> Result<(), String> {
     // Parse source into AST
     let mut ast = syntax::grammar::ProgramParser::new()
         .parse(source)
@@ -29,6 +34,6 @@ pub fn compile(source: &str) -> Result<(), String> {
     ir::run_passes(&mut ir);
 
     // Emit code (placeholder)
-    codegen::emit(&ir)?;
+    codegen::emit_with_backend(&ir, backend)?;
     Ok(())
 }

--- a/flux_lang/tests/backend_tests.rs
+++ b/flux_lang/tests/backend_tests.rs
@@ -1,0 +1,8 @@
+use flux_lang::{codegen::Backend, compile_with_backend};
+
+#[test]
+fn compile_with_all_backends() {
+    for backend in [Backend::Llvm, Backend::Cranelift, Backend::Wasm] {
+        assert!(compile_with_backend("", backend).is_ok());
+    }
+}

--- a/fluxc/src/main.rs
+++ b/fluxc/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::fs;
 
 /// FluxLang compiler CLI
@@ -15,18 +15,32 @@ enum Commands {
     Compile {
         #[arg(value_name = "FILE")]
         input: String,
+        #[arg(long, value_enum, default_value = "llvm")]
+        backend: BackendOpt,
     },
     /// Interactive REPL (not yet implemented)
     Repl,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]
+enum BackendOpt {
+    Llvm,
+    Cranelift,
+    Wasm,
 }
 
 fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Compile { input } => {
+        Commands::Compile { input, backend } => {
             let source = fs::read_to_string(&input).expect("failed to read input");
-            if let Err(e) = flux_lang::compile(&source) {
+            let backend = match backend {
+                BackendOpt::Llvm => flux_lang::codegen::Backend::Llvm,
+                BackendOpt::Cranelift => flux_lang::codegen::Backend::Cranelift,
+                BackendOpt::Wasm => flux_lang::codegen::Backend::Wasm,
+            };
+            if let Err(e) = flux_lang::compile_with_backend(&source, backend) {
                 eprintln!("compile error: {e}");
             }
         }


### PR DESCRIPTION
## Summary
- select backend in CLI and compiler
- support LLVM, Cranelift, and WASM emitters
- test compilation with each backend

## Testing
- `cargo clippy --all -- -D warnings`
- `cargo test --all`