### PR TITLE
Implement AST dumping CLI subcommand

### DIFF
--- a/flux_lang/tests/cli_tests.rs
+++ b/flux_lang/tests/cli_tests.rs
@@ -12,3 +12,16 @@ fn runs_fluxc() {
         eprintln!("CARGO_BIN_EXE_fluxc not set; skipping test");
     }
 }
+
+#[test]
+fn dumps_ast() {
+    if let Ok(exe) = std::env::var("CARGO_BIN_EXE_fluxc") {
+        let status = Command::new(exe)
+            .args(["ast", "examples/hello.flux"])
+            .status()
+            .expect("failed to run fluxc");
+        assert!(status.success());
+    } else {
+        eprintln!("CARGO_BIN_EXE_fluxc not set; skipping test");
+    }
+}

--- a/fluxc/src/main.rs
+++ b/fluxc/src/main.rs
@@ -18,6 +18,11 @@ enum Commands {
         #[arg(long, value_enum, default_value = "llvm")]
         backend: BackendOpt,
     },
+    /// Parse a FluxLang file and dump the AST
+    Ast {
+        #[arg(value_name = "FILE")]
+        input: String,
+    },
     /// Interactive REPL (not yet implemented)
     Repl,
 }
@@ -42,6 +47,13 @@ fn main() {
             };
             if let Err(e) = flux_lang::compile_with_backend(&source, backend) {
                 eprintln!("compile error: {e}");
+            }
+        }
+        Commands::Ast { input } => {
+            let source = fs::read_to_string(&input).expect("failed to read input");
+            match flux_lang::parse_program(&source) {
+                Ok(ast) => println!("{ast:#?}"),
+                Err(e) => eprintln!("parse error: {e}"),
             }
         }
         Commands::Repl => {


### PR DESCRIPTION
## Summary
- add a new `ast` subcommand to `fluxc` for dumping parsed ASTs
- test the new CLI action

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`