### PR TITLE
Allow lint workflow on all branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [master]
+    branches: ['*']
   pull_request:
-    branches: [master]
+    branches: ['*']
 
 jobs:
   clippy:


### PR DESCRIPTION
## Summary
- run lint CI for pushes and PRs on any branch

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`