### PR TITLE
Add quickcheck compile test and contributor workflow

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,11 @@
 # Contributing to FluxLang
 
 Thank you for considering contributing!
+
+## Development Workflow
+
+1. Format the code using `cargo fmt`.
+2. Run `cargo clippy -- -D warnings` to check for lints.
+3. Execute the full test suite with `cargo test`.
+
+Please ensure these steps succeed before opening a pull request.

--- a/flux_lang/tests/property_tests.rs
+++ b/flux_lang/tests/property_tests.rs
@@ -4,4 +4,11 @@ quickcheck! {
     fn addition_commutes(x: i32, y: i32) -> bool {
         x.wrapping_add(y) == y.wrapping_add(x)
     }
+
+    fn compile_never_panics(input: String) -> bool {
+        std::panic::catch_unwind(|| {
+            let _ = flux_lang::compile(&input);
+        })
+        .is_ok()
+    }
 }


### PR DESCRIPTION
## Summary
- document contribution workflow with formatting, linting, and tests
- check that compiling arbitrary input never panics

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`