### PR TITLE
Add CLI output option and test

### DIFF
--- a/flux_lang/tests/cli_tests.rs
+++ b/flux_lang/tests/cli_tests.rs
@@ -25,3 +25,16 @@ fn dumps_ast() {
         eprintln!("CARGO_BIN_EXE_fluxc not set; skipping test");
     }
 }
+
+#[test]
+fn compile_with_output() {
+    if let Ok(exe) = std::env::var("CARGO_BIN_EXE_fluxc") {
+        let status = Command::new(exe)
+            .args(["compile", "examples/hello.flux", "-o", "out.bin"])
+            .status()
+            .expect("failed to run fluxc");
+        assert!(status.success());
+    } else {
+        eprintln!("CARGO_BIN_EXE_fluxc not set; skipping test");
+    }
+}

--- a/fluxc/src/main.rs
+++ b/fluxc/src/main.rs
@@ -15,6 +15,8 @@ enum Commands {
     Compile {
         #[arg(value_name = "FILE")]
         input: String,
+        #[arg(short, long, value_name = "FILE")]
+        output: Option<String>,
         #[arg(long, value_enum, default_value = "llvm")]
         backend: BackendOpt,
     },
@@ -38,7 +40,11 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Compile { input, backend } => {
+        Commands::Compile {
+            input,
+            output,
+            backend,
+        } => {
             let source = fs::read_to_string(&input).expect("failed to read input");
             let backend = match backend {
                 BackendOpt::Llvm => flux_lang::codegen::Backend::Llvm,
@@ -47,6 +53,8 @@ fn main() {
             };
             if let Err(e) = flux_lang::compile_with_backend(&source, backend) {
                 eprintln!("compile error: {e}");
+            } else if let Some(path) = output {
+                println!("would write output to {path}");
             }
         }
         Commands::Ast { input } => {


### PR DESCRIPTION
## Summary
- add an optional `--output` argument to `fluxc compile`
- print the intended output file when compilation succeeds
- test the new CLI option

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --all --quiet`