### PR TITLE
Update syntax docs for semicolons

### DIFF
--- a/docs/BRAINSTORMING-SYNTAX.md
+++ b/docs/BRAINSTORMING-SYNTAX.md
@@ -1,14 +1,16 @@
 # FluxLang Syntax Brainstorming
 
 This document lists common programming tasks and records the emerging syntax decisions for FluxLang.  Each section describes the preferred syntax along with short reasoning on why competing ideas were removed.
+Statements are terminated with semicolons. Blocks do not require trailing semicolons.
+
 
 ## 1. Logging to the Console
 FluxLang will provide a small standard library.  Logging will mirror Rust so that developers feel at home.
 
 **Syntax**
 ```flux
-print("hello")
-log!("value = {}", x)
+print("hello");
+log!("value = {}", x);
 ```
 
 **Reasoning**: a function call and a macro cover simple printing and formatted debugging without new keywords like `emit`.
@@ -18,10 +20,10 @@ Variables can carry refinements and temporal qualifiers.  We keep the familiar `
 
 **Syntax**
 ```flux
-let count = 0
-let id: Int = 42
-let mut limit: Int where limit > 0 = 10
-let events@time: Stream<Event>
+let count = 0;
+let id: Int = 42;
+let mut limit: Int where limit > 0 = 10;
+let events@time: Stream<Event>;
 ```
 
 **Reasoning**: aligns with Rust while introducing refinements in a readable `where` clause.
@@ -31,9 +33,9 @@ Assignments behave like Rust with optional temporal indexing for future states.
 
 **Syntax**
 ```flux
-count = count + 1
-count += 1
-state[next] = update(state)
+count = count + 1;
+count += 1;
+state[next] = update(state);
 ```
 
 **Reasoning**: arrow based assignments conflicted with other uses of `->`; indexing with `[next]` keeps temporal updates explicit.
@@ -47,7 +49,7 @@ if cond { ... } else { ... }
 when phase if cond { ... } else { ... }
 ```
 
-**Reasoning**: removes less common forms (`cond { ... }`, ternaries) to keep the language concise.
+**Reasoning**: removes less common forms (`cond { ... };`, ternaries) to keep the language concise.
 
 ## 5. Looping Over a Range
 Numeric loops follow Rust's style and may attach refinements or temporal phases.
@@ -66,8 +68,8 @@ Collection iteration mirrors range loops and supports method chaining if desired
 
 **Syntax**
 ```flux
-for item in collection { ... }
-collection.each(|item| { ... })
+for item in collection { ... };
+collection.each(|item| { ... });
 ```
 
 **Reasoning**: removes `foreach` and `loop item of` alternatives to avoid multiple keywords for the same concept.
@@ -90,10 +92,10 @@ Calls look familiar and support explicit generics and async/await.
 
 **Syntax**
 ```flux
-add(1, 2)
-parse::<Int>("42")
-await fetch(url)
-plugin::transform!(input)
+add(1, 2);
+parse::<Int>("42");
+await fetch(url);
+plugin::transform!(input);
 ```
 **Reasoning**: retains Rust call syntax and macro invocation; other alternatives added little value.
 
@@ -102,8 +104,8 @@ Pattern matching follows Rust's `match` with optional guards.
 
 **Syntax**
 ```flux
-match value { Some(x) => x, None => default }
-match event if event.tag == "click" { Click(x, y) => ... }
+match value { Some(x) => x, None => default };
+match event if event.tag == "click" { Click(x, y) => ... };
 ```
 **Reasoning**: stream based `on` forms were removed to keep one clear construct; guards express refinement checks directly.
 
@@ -122,8 +124,8 @@ Instances use brace literals or associated constructors.
 
 **Syntax**
 ```flux
-let pt = Point { x: 0, y: 1 }
-let pt2 = Point::new(0, 1)
+let pt = Point { x: 0, y: 1 };
+let pt2 = Point::new(0, 1);
 ```
 **Reasoning**: avoids special `new` or builder keywords in favour of conventional forms.
 
@@ -132,8 +134,8 @@ Field access uses dot notation with optional temporal indexing.
 
 **Syntax**
 ```flux
-pt.x
-pt[next].x = 5
+pt.x;
+pt[next].x = 5;
 ```
 **Reasoning**: arrow operators and update blocks were removed for clarity; temporal writes reuse the indexing syntax from assignments.
 
@@ -142,9 +144,9 @@ Enums are declared with variant lists and can carry generics.
 
 **Syntax**
 ```flux
-enum Color { Red, Green, Blue }
-enum Option<T> { Some(T), None }
-enum Result<T, E> { Ok(T), Err(E) }
+enum Color { Red, Green, Blue };
+enum Option<T> { Some(T), None };
+enum Result<T, E> { Ok(T), Err(E) };
 ```
 **Reasoning**: bar separated and temporal enum forms were removed to keep the declaration style simple.
 
@@ -153,7 +155,7 @@ Matching values is done with the same `match` keyword used earlier.
 
 **Syntax**
 ```flux
-match value { Ok(v) => v, Err(e) => handle(e) }
+match value { Ok(v) => v, Err(e) => handle(e) };
 ```
 **Reasoning**: alternatives using `is` or `select` introduced redundant keywords without clear benefit.
 
@@ -162,8 +164,8 @@ Generics use angle brackets after the function name.  Bounds appear with `:` and
 
 **Syntax**
 ```flux
-fn identity<T>(val: T) -> T
-fn add<T: Numeric>(x: T, y: T) -> T
+fn identity<T>(val: T) -> T;
+fn add<T: Numeric>(x: T, y: T) -> T;
 ```
 **Reasoning**: choosing one placement for generics keeps parsing straightforward and matches common Rust practice.
 
@@ -172,9 +174,9 @@ Streams can be built from ranges, generators or channels.
 
 **Syntax**
 ```flux
-stream numbers = 0..n
-let s = stream { yield 1; yield 2 }
-channel<T>()
+stream numbers = 0..n;
+let s = stream { yield 1; yield 2 };
+channel<T>();
 ```
 **Reasoning**: the custom `flow` form conflicted with the desire to keep streams as first class values.
 
@@ -183,8 +185,8 @@ Consumption of streams uses an async-style `for await` loop or a `subscribe` hel
 
 **Syntax**
 ```flux
-for await value in my_stream { ... }
-subscribe(my_stream, |value| { ... })
+for await value in my_stream { ... };
+subscribe(my_stream, |value| { ... });
 ```
 **Reasoning**: a single keyword based approach is clearer than multiple custom constructs like `on` or `when emit`.
 
@@ -193,7 +195,7 @@ A pipeline operator expresses common combinators.
 
 **Syntax**
 ```flux
-stream |> map(f) |> filter(g)
+stream |> map(f) |> filter(g);
 ```
 **Reasoning**: chaining with `|>` reads left to right and avoids introducing numerous infix variants.
 
@@ -202,8 +204,8 @@ Refinement predicates appear in `where` clauses or new type definitions.
 
 **Syntax**
 ```flux
-let x: Int where x > 0 = 1
-type PosInt = Int where self > 0
+let x: Int where x > 0 = 1;
+type PosInt = Int where self > 0;
 ```
 **Reasoning**: natural language styles were dropped to keep the syntax concise and solver friendly.
 
@@ -212,9 +214,9 @@ Temporal qualifiers reuse the indexing notation and `@` markers.
 
 **Syntax**
 ```flux
-value@time
-state[next]
-Stream<Event>@phase
+value@time;
+state[next];
+Stream<Event>@phase;
 ```
 **Reasoning**: a uniform notation reduces confusion compared to keywords like `future`.
 
@@ -223,8 +225,8 @@ Imports follow Rust-style paths and `export` marks public items.
 
 **Syntax**
 ```flux
-import math::trig::{sin, cos}
-export fn calc()
+import math::trig::{sin, cos};
+export fn calc();
 ```
 **Reasoning**: avoids Python-like `from` and keeps module syntax consistent with the rest of the language.
 
@@ -233,8 +235,8 @@ Macros use a `macro` keyword with arrow expansion and are invoked with `!` when 
 
 **Syntax**
 ```flux
-macro greet(name) => { print("hi {name}") }
-greet!("world")
+macro greet(name) => { print("hi {name}") };
+greet!("world");
 ```
 **Reasoning**: standardising on one definition form simplifies macro tooling.
 
@@ -243,7 +245,7 @@ FluxLang provides `Result` and a `try` block with the `?` operator for propagati
 
 **Syntax**
 ```flux
-try { risky()? }
+try { risky()? };
 ```
 **Reasoning**: stream-specific error combinators can be built as library functions; keeping the core syntax minimal helps reasoning about control flow.
 
@@ -252,8 +254,8 @@ Scoped resource blocks and a `defer` statement manage cleanup.
 
 **Syntax**
 ```flux
-with file = open(path) { ... }
-let file = open(path); defer file.close()
+with file = open(path) { ... };
+let file = open(path); defer file.close();
 ```
 **Reasoning**: these two forms cover common RAII patterns without extra keywords like `resource` or `dispose`.
 
@@ -263,8 +265,8 @@ Asynchronous tasks resemble Rust's async model with lightweight spawning.
 **Syntax**
 ```flux
 spawn { ... }
-let handle = async_run(f())
-await join(handle)
+let handle = async_run(f());
+await join(handle);
 ```
 **Reasoning**: dropping the `go` keyword and parallel for loops keeps concurrency primitives orthogonal to the rest of the language.
 
@@ -272,9 +274,9 @@ await join(handle)
 Testing helps validate both semantics and refinement proofs.
 
 Selected syntax ideas:
-* `test "adds numbers" { assert(add(2,2) == 4) }` – lightweight inline test block.
-* `#[test] fn adds() { assert(add(2,2) == 4) }` – Rust‑style attribute test.
-* `spec add_positive(x: Int, y: Int) [x > 0, y > 0] => { add(x, y) > 0 }` – property specification leveraging refinements.
+* `test "adds numbers" { assert(add(2,2) == 4) };` – lightweight inline test block.
+* `#[test] fn adds() { assert(add(2,2) == 4) };` – Rust‑style attribute test.
+* `spec add_positive(x: Int, y: Int) [x > 0, y > 0] => { add(x, y) > 0 };` – property specification leveraging refinements.
 
 **Reasoning**: providing both block and attribute styles allows quick checks and
 integration with tooling. A specification form illustrates how refinement logic
@@ -284,9 +286,9 @@ can drive property tests.
 Interoperability with existing libraries is essential for adoption.
 
 Selected syntax ideas:
-* `extern fn c_func(arg: Int) -> Int` – direct declaration of an external function.
-* `@ffi("libm") fn sin(x: Float) -> Float` – attribute specifying the foreign library.
-* `link "c" { fn printf(format: *const u8, ...) }` – grouped declarations inside a link block.
+* `extern fn c_func(arg: Int) -> Int`; – direct declaration of an external function.
+* `@ffi("libm") fn sin(x: Float) -> Float`; – attribute specifying the foreign library.
+* `link "c" { fn printf(format: *const u8, ...) };` – grouped declarations inside a link block.
 
 **Reasoning**: the FFI syntax mirrors Rust's approach but adds attributes for
 explicit library names. Grouped declarations make large foreign interfaces more
@@ -297,7 +299,7 @@ FluxLang traits describe shared behaviour similar to Rust's traits.
 
 **Syntax**
 ```flux
-trait Printable { fn print(self) }
+trait Printable { fn print(self) };
 ```
 **Reasoning**: adding traits fills a gap in the original list and provides a foundation for generics and interfaces.
 
@@ -306,7 +308,7 @@ Implementations associate trait methods with concrete types.
 
 **Syntax**
 ```flux
-impl Printable for Point { fn print(self) { print("({},{})", self.x, self.y) } }
+impl Printable for Point { fn print(self) { print("({},{})", self.x, self.y) } };
 ```
 **Reasoning**: mirrors Rust's `impl` syntax so tooling and developers can easily adapt.
 
@@ -316,8 +318,8 @@ Closures enable concise inline functions.
 
 **Syntax**
 ```flux
-let inc = |x| x + 1
-collection.map(|x| x * 2)
+let inc = |x| x + 1;
+collection.map(|x| x * 2);
 ```
 **Reasoning**: Lambdas are commonplace in modern languages and work well with stream combinators.
 
@@ -327,7 +329,7 @@ Rust-style documentation comments integrate with tooling.
 **Syntax**
 ```flux
 /// Adds two numbers.
-fn add(x: Int, y: Int) -> Int { x + y }
+fn add(x: Int, y: Int) -> Int { x + y };
 ```
 **Reasoning**: Keeping docs next to code encourages comprehensive documentation without new keywords.
 
@@ -336,7 +338,7 @@ Constant values are declared with `const`.
 
 **Syntax**
 ```flux
-const MAX: Int = 10
+const MAX: Int = 10;
 fn array(len: Int = MAX) -> [Int; len]
 ```
 **Reasoning**: A clear `const` form avoids using macros for simple constants and enables compile-time evaluation.
@@ -347,9 +349,9 @@ Attributes annotate declarations with metadata.
 **Syntax**
 ```flux
 #[inline]
-fn compute() { ... }
+fn compute() { ... };
 
 #[temporal(after = tick)]
-fn step(time: Time) -> Output @ (time + 1) { ... }
+fn step(time: Time) -> Output @ (time + 1) { ... };
 ```
 **Reasoning**: Attributes are a flexible mechanism to express hints and temporal semantics consistently across the language.


### PR DESCRIPTION
## Summary
- clarify that statements use semicolons
- update all syntax snippets to show trailing semicolons

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`
