### PR TITLE
Add plugin clearing function and use in tests

### DIFF
--- a/flux_lang/src/plugins/mod.rs
+++ b/flux_lang/src/plugins/mod.rs
@@ -1,3 +1,9 @@
+//! Plugin infrastructure for FluxLang.
+//!
+//! Plugins can be registered with [`register`] and executed with [`run_all`].
+//! Tests should call [`clear_plugins`] to remove any previously registered
+//! plugins so state does not leak between test cases.
+
 use crate::syntax::ast::Program;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
@@ -12,6 +18,14 @@ static PLUGINS: Lazy<Mutex<Vec<Box<dyn Plugin>>>> = Lazy::new(|| Mutex::new(Vec:
 
 pub fn register(plugin: Box<dyn Plugin>) {
     PLUGINS.lock().unwrap().push(plugin);
+}
+
+/// Remove all registered plugins.
+///
+/// Mainly used by tests to ensure plugins registered in one test do not
+/// affect others.
+pub fn clear_plugins() {
+    PLUGINS.lock().unwrap().clear();
 }
 
 pub fn run_all(program: &mut Program) {

--- a/flux_lang/tests/backend_tests.rs
+++ b/flux_lang/tests/backend_tests.rs
@@ -1,7 +1,8 @@
-use flux_lang::{codegen::Backend, compile_with_backend};
+use flux_lang::{codegen::Backend, compile_with_backend, plugins};
 
 #[test]
 fn compile_with_all_backends() {
+    plugins::clear_plugins();
     for backend in [Backend::Llvm, Backend::Cranelift, Backend::Wasm] {
         assert!(compile_with_backend("", backend).is_ok());
     }

--- a/flux_lang/tests/parser_tests.rs
+++ b/flux_lang/tests/parser_tests.rs
@@ -1,12 +1,14 @@
-use flux_lang::{compile, parse_program};
+use flux_lang::{compile, parse_program, plugins};
 
 #[test]
 fn compile_empty_source() {
+    plugins::clear_plugins();
     assert!(compile("").is_ok());
 }
 
 #[test]
 fn parse_returns_ast() {
+    plugins::clear_plugins();
     let ast = parse_program("").expect("parse failure");
     assert_eq!(format!("{ast:?}"), "Program");
 }

--- a/flux_lang/tests/property_tests.rs
+++ b/flux_lang/tests/property_tests.rs
@@ -1,3 +1,4 @@
+use flux_lang::plugins;
 use quickcheck::quickcheck;
 
 quickcheck! {
@@ -6,6 +7,7 @@ quickcheck! {
     }
 
     fn compile_never_panics(input: String) -> bool {
+        plugins::clear_plugins();
         std::panic::catch_unwind(|| {
             let _ = flux_lang::compile(&input);
         })

--- a/flux_lang/tests/typechecker_tests.rs
+++ b/flux_lang/tests/typechecker_tests.rs
@@ -1,6 +1,7 @@
-use flux_lang::compile;
+use flux_lang::{compile, plugins};
 
 #[test]
 fn typechecker_stub() {
+    plugins::clear_plugins();
     assert!(compile("dummy").is_ok());
 }


### PR DESCRIPTION
## Summary
- add `clear_plugins` API and document the plugin module
- use `clear_plugins` in tests to avoid shared plugin state

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
