### PR TITLE
Add option to skip default plugins

### DIFF
--- a/flux_lang/src/lib.rs
+++ b/flux_lang/src/lib.rs
@@ -30,7 +30,9 @@ pub fn compile_with_backend(source: &str, backend: codegen::Backend) -> Result<(
     macros::expand(&mut ast);
 
     // Register and run development plugins
-    plugins::register_default_plugins();
+    if std::env::var_os("FLUX_SKIP_DEFAULT_PLUGINS").is_none() {
+        plugins::register_default_plugins();
+    }
     plugins::run_all(&mut ast);
 
     // Type check

--- a/flux_lang/tests/plugin_env_tests.rs
+++ b/flux_lang/tests/plugin_env_tests.rs
@@ -1,0 +1,29 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use flux_lang::{
+    codegen::Backend,
+    compile_with_backend,
+    plugins::{self, Plugin},
+};
+
+struct CountingPlugin(Arc<AtomicUsize>);
+
+impl Plugin for CountingPlugin {
+    fn run(&self, _program: &mut flux_lang::syntax::ast::Program) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn skip_default_plugins_env() {
+    plugins::clear_plugins();
+    let counter = Arc::new(AtomicUsize::new(0));
+    plugins::register(Box::new(CountingPlugin(counter.clone())));
+    std::env::set_var("FLUX_SKIP_DEFAULT_PLUGINS", "1");
+    compile_with_backend("", Backend::Llvm).unwrap();
+    std::env::remove_var("FLUX_SKIP_DEFAULT_PLUGINS");
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
## Summary
- allow compile_with_backend to skip registering default plugins using env var `FLUX_SKIP_DEFAULT_PLUGINS`
- test skipping default plugins via new `plugin_env_tests`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
