### PR TITLE
Add syntax util for offset mapping

### DIFF
--- a/flux_lang/src/lib.rs
+++ b/flux_lang/src/lib.rs
@@ -17,23 +17,6 @@ pub fn compile(source: &str) -> Result<()> {
 
 /// Parse FluxLang source into an AST.
 pub fn parse_program(source: &str) -> Result<syntax::ast::Program> {
-    fn offset_to_line_col(src: &str, offset: usize) -> (usize, usize) {
-        let mut line = 0usize;
-        let mut col = 0usize;
-        for (i, ch) in src.char_indices() {
-            if i == offset {
-                break;
-            }
-            if ch == '\n' {
-                line += 1;
-                col = 0;
-            } else {
-                col += 1;
-            }
-        }
-        (line, col)
-    }
-
     syntax::grammar::ProgramParser::new()
         .parse(source)
         .map_err(|e: LalrpopError<usize, _, _>| {
@@ -54,7 +37,7 @@ pub fn parse_program(source: &str) -> Result<syntax::ast::Program> {
                 ExtraToken { token: (loc, _, _) } => (loc, "extra token".to_string()),
                 User { error } => (0, error.to_string()),
             };
-            let (line, column) = offset_to_line_col(source, offset);
+            let (line, column) = syntax::util::offset_to_line_col(source, offset);
             anyhow!(syntax::ParseError {
                 line,
                 column,

--- a/flux_lang/src/syntax/mod.rs
+++ b/flux_lang/src/syntax/mod.rs
@@ -8,6 +8,7 @@ pub mod grammar {
 
 pub mod ast;
 pub mod lexer;
+pub mod util;
 
 /// Error returned when parsing source fails.
 #[derive(Debug)]

--- a/flux_lang/src/syntax/util.rs
+++ b/flux_lang/src/syntax/util.rs
@@ -1,0 +1,39 @@
+//! Utility functions for syntax operations.
+
+/// Convert a character offset within `src` to a zero-based (line, column) pair.
+///
+/// Lines are separated by `\n` characters.
+pub fn offset_to_line_col(src: &str, offset: usize) -> (usize, usize) {
+    let mut line = 0usize;
+    let mut col = 0usize;
+    for (i, ch) in src.char_indices() {
+        if i == offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::offset_to_line_col;
+
+    #[test]
+    fn calculates_first_line() {
+        assert_eq!(offset_to_line_col("abc", 2), (0, 2));
+    }
+
+    #[test]
+    fn calculates_multiline() {
+        let src = "a\nbc\nde";
+        assert_eq!(offset_to_line_col(src, 0), (0, 0));
+        assert_eq!(offset_to_line_col(src, 2), (1, 0));
+        assert_eq!(offset_to_line_col(src, 5), (2, 0));
+    }
+}


### PR DESCRIPTION
## Summary
- add `syntax::util` module with `offset_to_line_col`
- use `offset_to_line_col` in `parse_program`
- test `offset_to_line_col`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
