### PR TITLE
Add cargo audit to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,3 +24,7 @@ jobs:
         run: cargo clippy --all -- -D warnings
       - name: Rustfmt Check
         run: cargo fmt -- --check
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      - name: Cargo Audit
+        run: cargo audit


### PR DESCRIPTION
## Summary
- run `cargo install cargo-audit`
- run `cargo audit` in lint workflow

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
