### PR TITLE
Introduce PluginRegistry for managing plugins

### DIFF
--- a/flux_lang/src/lib.rs
+++ b/flux_lang/src/lib.rs
@@ -75,7 +75,7 @@ pub fn compile_with_backend(source: &str, backend: codegen::Backend) -> Result<(
     if std::env::var_os("FLUX_SKIP_DEFAULT_PLUGINS").is_none() {
         plugins::register_default_plugins();
     }
-    plugins::run_all(&mut ast);
+    plugins::REGISTRY.run_all(&mut ast);
 
     // Type check
     semantic::check(&ast)?;

--- a/flux_lang/src/plugins/mod.rs
+++ b/flux_lang/src/plugins/mod.rs
@@ -1,8 +1,8 @@
 //! Plugin infrastructure for FluxLang.
 //!
-//! Plugins can be registered with [`register`] and executed with [`run_all`].
-//! Tests should call [`clear_plugins`] to remove any previously registered
-//! plugins so state does not leak between test cases.
+//! Plugins can be registered with [`REGISTRY.register`] and executed with
+//! [`REGISTRY.run_all`]. Tests should call [`REGISTRY.clear`] to remove any
+//! previously registered plugins so state does not leak between test cases.
 
 use crate::syntax::ast::Program;
 use once_cell::sync::Lazy;
@@ -14,27 +14,31 @@ pub trait Plugin: Send + Sync {
 
 pub mod example;
 
-static PLUGINS: Lazy<Mutex<Vec<Box<dyn Plugin>>>> = Lazy::new(|| Mutex::new(Vec::new()));
+pub struct PluginRegistry(Mutex<Vec<Box<dyn Plugin>>>);
 
-pub fn register(plugin: Box<dyn Plugin>) {
-    PLUGINS.lock().unwrap().push(plugin);
-}
+impl PluginRegistry {
+    pub fn register(&self, plugin: Box<dyn Plugin>) {
+        self.0.lock().unwrap().push(plugin);
+    }
 
-/// Remove all registered plugins.
-///
-/// Mainly used by tests to ensure plugins registered in one test do not
-/// affect others.
-pub fn clear_plugins() {
-    PLUGINS.lock().unwrap().clear();
-}
+    /// Remove all registered plugins.
+    ///
+    /// Mainly used by tests to ensure plugins registered in one test do not
+    /// affect others.
+    pub fn clear(&self) {
+        self.0.lock().unwrap().clear();
+    }
 
-pub fn run_all(program: &mut Program) {
-    for plugin in PLUGINS.lock().unwrap().iter() {
-        plugin.run(program);
+    pub fn run_all(&self, program: &mut Program) {
+        for plugin in self.0.lock().unwrap().iter() {
+            plugin.run(program);
+        }
     }
 }
 
+pub static REGISTRY: Lazy<PluginRegistry> = Lazy::new(|| PluginRegistry(Mutex::new(Vec::new())));
+
 /// Register built-in plugins used during development.
 pub fn register_default_plugins() {
-    register(Box::new(example::DumpAstPlugin));
+    REGISTRY.register(Box::new(example::DumpAstPlugin));
 }

--- a/flux_lang/tests/backend_tests.rs
+++ b/flux_lang/tests/backend_tests.rs
@@ -2,7 +2,7 @@ use flux_lang::{codegen::Backend, compile_with_backend, plugins};
 
 #[test]
 fn compile_with_all_backends() {
-    plugins::clear_plugins();
+    plugins::REGISTRY.clear();
     for backend in [Backend::Llvm, Backend::Cranelift, Backend::Wasm] {
         assert!(compile_with_backend("", backend).is_ok());
     }

--- a/flux_lang/tests/parser_tests.rs
+++ b/flux_lang/tests/parser_tests.rs
@@ -2,20 +2,20 @@ use flux_lang::{compile, parse_program, plugins};
 
 #[test]
 fn compile_empty_source() {
-    plugins::clear_plugins();
+    plugins::REGISTRY.clear();
     assert!(compile("").is_ok());
 }
 
 #[test]
 fn parse_returns_ast() {
-    plugins::clear_plugins();
+    plugins::REGISTRY.clear();
     let ast = parse_program("").expect("parse failure");
     assert_eq!(format!("{ast:?}"), "Program");
 }
 
 #[test]
 fn parse_error_reports_location() {
-    plugins::clear_plugins();
+    plugins::REGISTRY.clear();
     let err = parse_program("1").unwrap_err();
     let pe = err
         .downcast_ref::<flux_lang::syntax::ParseError>()

--- a/flux_lang/tests/plugin_env_tests.rs
+++ b/flux_lang/tests/plugin_env_tests.rs
@@ -19,9 +19,9 @@ impl Plugin for CountingPlugin {
 
 #[test]
 fn skip_default_plugins_env() {
-    plugins::clear_plugins();
+    plugins::REGISTRY.clear();
     let counter = Arc::new(AtomicUsize::new(0));
-    plugins::register(Box::new(CountingPlugin(counter.clone())));
+    plugins::REGISTRY.register(Box::new(CountingPlugin(counter.clone())));
     std::env::set_var("FLUX_SKIP_DEFAULT_PLUGINS", "1");
     compile_with_backend("", Backend::Llvm).unwrap();
     std::env::remove_var("FLUX_SKIP_DEFAULT_PLUGINS");

--- a/flux_lang/tests/property_tests.rs
+++ b/flux_lang/tests/property_tests.rs
@@ -7,7 +7,7 @@ quickcheck! {
     }
 
     fn compile_never_panics(input: String) -> bool {
-        plugins::clear_plugins();
+        plugins::REGISTRY.clear();
         std::panic::catch_unwind(|| {
             let _ = flux_lang::compile(&input);
         })

--- a/flux_lang/tests/typechecker_tests.rs
+++ b/flux_lang/tests/typechecker_tests.rs
@@ -2,6 +2,6 @@ use flux_lang::{compile, plugins};
 
 #[test]
 fn typechecker_stub() {
-    plugins::clear_plugins();
+    plugins::REGISTRY.clear();
     assert!(compile("dummy").is_ok());
 }


### PR DESCRIPTION
## Summary
- define `PluginRegistry` managing plugin registration, clearing, and execution
- replace static plugin list with `REGISTRY`
- update compiler and tests to use the registry

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
